### PR TITLE
Added 'Add Remark' text field to manage-posts for admins to put Remar…

### DIFF
--- a/src/app/dashboard/admin/manage-posts/page.tsx
+++ b/src/app/dashboard/admin/manage-posts/page.tsx
@@ -115,7 +115,7 @@ export default function ManagePostPage() {
 
             {/* DIVIDER */}
 
-            <div className='w-full max-w-270 py-5 flex flex-row md:flex-row  gap-6 items-center justify-end'>
+            <div className='w-full max-w-270 py-5 flex flex-row md:flex-row  gap-6 items-center justify-center md:justify-end'>
                 <div className='flex flex-row items-center gap-2'>
                     {/* Filter Post by Type */}
                     <DropdownMenu open={openType} onOpenChange={setOpenType}>
@@ -204,16 +204,16 @@ export default function ManagePostPage() {
             {/* Post Cards */}
             <div className='w-full max-w-270 pb-6'>
                 <div className='w-full bg-white rounded-lg p-6 border border-[#B2B8EE] flex flex-col gap-3'>
-                    <PostList title="Final Examination Schedule for Semester 2, Including All Subjects and Updated Timetable Adjustments for Students" date="12 March 2025" status="Approved" showStatus={true} postType='Hockey Club' />
-                    <PostList title="Math Quiz" date="14 March 2025" status="Pending" showStatus={true} postType='3 Al Farabi' />
-                    <PostList title="Important Announcement Regarding the Upcoming Parent-Teacher Meeting and Classroom Activities for the Weekt" date="15 March 2025" status="Remarked" showStatus={true} postType='4 CQalyubi' />
-                    <PostList title="English Essay" date="16 March 2025" status="Rejected" showStatus={true} postType='Climbing Club' />
+                    <PostList title="Final Examination Schedule for Semester 2, Including All Subjects and Updated Timetable Adjustments for Students" date="12 March 2025" status="Approved" showStatus={true} postType='Hockey Club' showDelete={false} useActionModal={true} />
+                    {/* <PostList title="Math Quiz" date="14 March 2025" status="Pending" showStatus={true} postType='3 Al Farabi' showDelete={false} />
+                    <PostList title="Important Announcement Regarding the Upcoming Parent-Teacher Meeting and Classroom Activities for the Weekt" date="15 March 2025" status="Remarked" showStatus={true} postType='4 CQalyubi' showDelete={false} />
+                    <PostList title="English Essay" date="16 March 2025" status="Rejected" showStatus={true} postType='Climbing Club' showDelete={false} />
                     <PostList title="English Essay" date="16 March 2025" status="Rejected" showStatus={true} postType='1 Al Dinawari' />
-                    <PostList title="Invitation to Participate in the Schools Cultural Festival Featuring Performances, Exhibitions, and Workshops" date="12 March 2025" status="Approved" showStatus={true} postType='5 Al Farabi' />
-                    <PostList title="Math Quiz" date="14 March 2025" status="Pending" showStatus={true} postType='Pantun Club' />
-                    <PostList title="Science Project" date="15 March 2025" status="Remarked" showStatus={true} postType='3 Al Farabi' />
-                    <PostList title="Invitation to Participate in the Schools Cultural Festival Featuring Performances, Exhibitions, and Workshops" date="16 March 2025" status="Rejected" showStatus={true} postType='3 Al Farabibibibibibibibibibibibibibi' />
-                    <PostList title="English Essay" date="16 March 2025" status="Rejected" showStatus={true} postType='Drama Club' />
+                    <PostList title="Invitation to Participate in the Schools Cultural Festival Featuring Performances, Exhibitions, and Workshops" date="12 March 2025" status="Approved" showStatus={true} postType='5 Al Farabi' showDelete={false} />
+                    <PostList title="Math Quiz" date="14 March 2025" status="Pending" showStatus={true} postType='Pantun Club' showDelete={false} />
+                    <PostList title="Science Project" date="15 March 2025" status="Remarked" showStatus={true} postType='3 Al Farabi' showDelete={false} />
+                    <PostList title="Invitation to Participate in the Schools Cultural Festival Featuring Performances, Exhibitions, and Workshops" date="16 March 2025" status="Rejected" showStatus={true} postType='3 Al Farabibibibibibibibibibibibibibi' showDelete={false} />
+                    <PostList title="English Essay" date="16 March 2025" status="Rejected" showStatus={true} postType='Drama Club' showDelete={false} /> */}
 
                 </div>
             </div>

--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -105,16 +105,16 @@ export default function AdminDashboardPage() {
             {/* Post Cards */}
             <div className='w-full max-w-270 pb-6'>
                 <div className='w-full bg-white rounded-lg p-6 border border-[#B2B8EE] flex flex-col gap-3'>
-                    <PostList title="Final Examination Schedule for Semester 2, Including All Subjects and Updated Timetable Adjustments for Students" date="12 March 2025" status="Approved" showStatus={false} />
-                    <PostList title="Math Quiz" date="14 March 2025" status="Pending" showStatus={false} />
-                    <PostList title="Important Announcement Regarding the Upcoming Parent-Teacher Meeting and Classroom Activities for the Weekt" date="15 March 2025" status="Remarked" showStatus={false} />
-                    <PostList title="English Essay" date="16 March 2025" status="Rejected" showStatus={false} />
-                    <PostList title="English Essay" date="16 March 2025" status="Rejected" showStatus={false} />
-                    <PostList title="Invitation to Participate in the Schools Cultural Festival Featuring Performances, Exhibitions, and Workshops" date="12 March 2025" status="Approved" showStatus={false} />
-                    <PostList title="Math Quiz" date="14 March 2025" status="Pending" showStatus={false} />
-                    <PostList title="Science Project" date="15 March 2025" status="Remarked" showStatus={false} />
-                    <PostList title="Invitation to Participate in the Schools Cultural Festival Featuring Performances, Exhibitions, and Workshops" date="16 March 2025" status="Rejected" showStatus={false} />
-                    <PostList title="English Essay" date="16 March 2025" status="Rejected" showStatus={false} />
+                    <PostList title="Final Examination Schedule for Semester 2, Including All Subjects and Updated Timetable Adjustments for Students" date="12 March 2025" status="Approved" showStatus={false} showDot={false} showAddRemarkBox={false} />
+                    {/* <PostList title="Math Quiz" date="14 March 2025" status="Pending" showStatus={false} showDot={false} />
+                    <PostList title="Important Announcement Regarding the Upcoming Parent-Teacher Meeting and Classroom Activities for the Weekt" date="15 March 2025" status="Remarked" showStatus={false} showDot={false} />
+                    <PostList title="English Essay" date="16 March 2025" status="Rejected" showStatus={false} showDot={false} />
+                    <PostList title="English Essay" date="16 March 2025" status="Rejected" showStatus={false} showDot={false} />
+                    <PostList title="Invitation to Participate in the Schools Cultural Festival Featuring Performances, Exhibitions, and Workshops" date="12 March 2025" status="Approved" showStatus={false} showDot={false} />
+                    <PostList title="Math Quiz" date="14 March 2025" status="Pending" showStatus={false} showDot={false} />
+                    <PostList title="Science Project" date="15 March 2025" status="Remarked" showStatus={false} showDot={false} />
+                    <PostList title="Invitation to Participate in the Schools Cultural Festival Featuring Performances, Exhibitions, and Workshops" date="16 March 2025" status="Rejected" showStatus={false} showDot={false} />
+                    <PostList title="English Essay" date="16 March 2025" status="Rejected" showStatus={false} showDot={false} /> */}
 
                 </div>
             </div>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -25,11 +25,6 @@ export default function RootLayout({
             <body className="min-h-screen flex flex-col">
                 <Navbar />
                 <main className="flex-grow bg-gradient-to-b from-[#B2B8EE] to-[#F3F4FE]">
-                    {/* <div className="w-full max-w-170 px-5 pb-5 flex justify-center items-center m-auto">
-                        <Command>
-                            <CommandInput placeholder="Search school..." />
-                        </Command>
-                    </div> */}
                     {children}
                 </main>
                 <Footer />

--- a/src/app/dashboard/teacher/page.tsx
+++ b/src/app/dashboard/teacher/page.tsx
@@ -167,8 +167,8 @@ export default function TeacherDashboardPage() {
             {/* Post Cards */}
             <div className='w-full max-w-270 pb-6'>
                 <div className='w-full bg-white rounded-lg p-6 border border-[#B2B8EE] flex flex-col gap-3'>
-                    <PostList title="Final Examination Schedule for Semester 2, Including All Subjects and Updated Timetable Adjustments for Students" date="12 March 2025" status="Approved" />
-                    <PostList title="Math Quiz" date="14 March 2025" status="Pending" />
+                    <PostList title="Final Examination Schedule for Semester 2, Including All Subjects and Updated Timetable Adjustments for Students" date="12 March 2025" status="Approved" showAddRemarkBox={false} />
+                    {/* <PostList title="Math Quiz" date="14 March 2025" status="Pending" />
                     <PostList title="Important Announcement Regarding the Upcoming Parent-Teacher Meeting and Classroom Activities for the Weekt" date="15 March 2025" status="Remarked" />
                     <PostList title="English Essay" date="16 March 2025" status="Rejected" />
                     <PostList title="English Essay" date="16 March 2025" status="Rejected" />
@@ -176,7 +176,7 @@ export default function TeacherDashboardPage() {
                     <PostList title="Math Quiz" date="14 March 2025" status="Pending" />
                     <PostList title="Science Project" date="15 March 2025" status="Remarked" />
                     <PostList title="Invitation to Participate in the Schools Cultural Festival Featuring Performances, Exhibitions, and Workshops" date="16 March 2025" status="Rejected" />
-                    <PostList title="English Essay" date="16 March 2025" status="Rejected" />
+                    <PostList title="English Essay" date="16 March 2025" status="Rejected" /> */}
 
                 </div>
             </div>

--- a/src/components/ActionModal.tsx
+++ b/src/components/ActionModal.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import * as React from "react";
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogDescription,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+
+import { Button } from "@/components/ui/button";
+
+interface ActionModalProps {
+    trigger: React.ReactNode; // what opens the modal (e.g. PencilSimpleIcon)
+    onApprove?: () => void;
+    onRemark?: (remark: string) => void;
+    onReject?: (remark: string) => void;
+    remarkText?: string;
+}
+
+export default function ActionModal({
+    trigger,
+    onApprove,
+    onRemark,
+    onReject,
+    remarkText,
+}: ActionModalProps) {
+    return (
+        <Dialog>
+            <DialogTrigger asChild>{trigger}</DialogTrigger>
+            <DialogContent className="max-w-sm">
+                <DialogHeader>
+                    <DialogTitle className="text-lg font-semibold text-[#243056]">
+                        Manage Post
+                    </DialogTitle>
+                    <DialogDescription className='leading-3'>
+                        Approve, remark, or reject the post.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="flex flex-col gap-3 py-4">
+                    <Button
+                        className="border font-semibold border-green-400 text-green-400 bg-green-50 hover:bg-green-400 rounded-full hover:cursor-pointer hover:text-white"
+                        onClick={onApprove}
+                    >
+                        Approve
+                    </Button>
+
+                    <Button
+                        className="border font-semibold border-blue-400 text-blue-400 bg-blue-50 hover:bg-blue-400 rounded-full hover:cursor-pointer hover:text-white"
+                        onClick={() => {
+                            if (!remarkText || remarkText.trim() === "") {
+                                alert("Please provide remarks before remarking this post.");
+                                return;
+                            }
+                            onRemark?.(remarkText);
+                        }}
+                    >
+                        Remark
+                    </Button>
+
+                    <Button
+                        className="border font-semibold border-red-500 text-red-500 bg-red-50 hover:bg-red-500 rounded-full hover:cursor-pointer hover:text-white"
+                        onClick={() => {
+                            if (!remarkText || remarkText.trim() === "") {
+                                alert("Please provide remarks before rejecting this post.");
+                                return;
+                            }
+                            onReject?.(remarkText);
+                        }}
+                    >
+                        Reject
+                    </Button>
+                </div>
+
+
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/components/AddRemarkBox.tsx
+++ b/src/components/AddRemarkBox.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { ChatIcon } from "@phosphor-icons/react";
+import { Textarea } from "@/components/ui/textarea";
+
+interface AddRemarkBoxProps {
+    value: string;
+    onChange: (value: string) => void;
+}
+
+const AddRemarkBox: React.FC<AddRemarkBoxProps> = ({ value, onChange }) => {
+    return (
+        <div className="flex flex-col p-3 gap-3 bg-[#FFFFFF] border-1 border-[#B5B5B5] rounded-md">
+            <div className="flex flex-row items-center gap-2">
+                <ChatIcon size={20} weight="bold" className='text-[#7B7C7D]' />
+                <a className="text-[#7B7C7D] font-semibold">Add Remarks</a>
+            </div>
+            <Textarea id="content" placeholder="Give remarks when Remarking or Rejecting a post." rows={2} value={value} onChange={(e) => onChange(e.target.value)} />
+        </div>
+    );
+};
+
+export default AddRemarkBox;

--- a/src/components/CreatePostModal.tsx
+++ b/src/components/CreatePostModal.tsx
@@ -37,7 +37,7 @@ export default function CreatePostModal({ open, onOpenChange }: CreatePostModalP
                     {/* Content */}
                     <div className="flex flex-col gap-1">
                         <Label htmlFor="content" className='text-[#243056] pb-1 font-semibold'>Description*</Label>
-                        <Textarea id="content" placeholder="Share the detials of the post.." rows={5} />
+                        <Textarea id="content" placeholder="Share the details of the post.." rows={5} />
                     </div>
 
                     {/* Tags */}

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -6,6 +6,8 @@ import { Button } from "@/components/ui/button"
 import { ImageGallery } from "./ImageGallery";
 import EditPostModal from "./EditPostModal";
 import RemarkBox from "./RemarkBox";
+import AddRemarkBox from "./AddRemarkBox";
+import ActionModal from "./ActionModal";
 
 interface PostListProps {
     title: string;
@@ -13,9 +15,13 @@ interface PostListProps {
     status: "Approved" | "Pending" | "Remarked" | "Rejected";
     showStatus?: boolean;
     postType?: string;
+    showDot?: boolean;
+    showDelete?: boolean
+    useActionModal?: boolean;
+    showAddRemarkBox?: boolean;
 }
 
-const PostList: React.FC<PostListProps> = ({ title, date, status, showStatus = true, postType }) => {
+const PostList: React.FC<PostListProps> = ({ title, date, status, showStatus = true, postType, showDot = true, showDelete = true, useActionModal = false, showAddRemarkBox = true }) => {
 
     const images = [
         "/images4.jpeg",
@@ -34,6 +40,9 @@ const PostList: React.FC<PostListProps> = ({ title, date, status, showStatus = t
 
     const [openPost, setOpenPost] = React.useState(false);
     const [openEditPost, setOpenEditPost] = React.useState(false);
+
+    const [remarkText, setRemarkText] = React.useState("");
+
 
     const statusColorMap: Record<string, "green" | "yellow" | "blue" | "red"> = {
         Approved: "green",
@@ -60,7 +69,9 @@ const PostList: React.FC<PostListProps> = ({ title, date, status, showStatus = t
                     {/* Date */}
                     <span className="text-[#6E7793] text-right whitespace-nowrap">{date}</span>
 
-                    <DotOutlineIcon size={20} weight="bold" className="text-[#6E7793] md:flex lg:flex" />
+                    {showDot &&
+                        <DotOutlineIcon size={20} weight="bold" className="text-[#6E7793] md:flex lg:flex" />
+                    }
 
                     {/* Post Type */}
                     {postType &&
@@ -124,10 +135,38 @@ const PostList: React.FC<PostListProps> = ({ title, date, status, showStatus = t
                                 </div>
 
                                 <div className="flex gap-2 sm: justify-center sm:items-center mt-2 sm:mt-0">
-                                    <PencilSimpleIcon size={25} weight="bold" onClick={() => setOpenEditPost(true)} className="text-blue-400 hover:text-blue-500 transition-colors duration-200 cursor-pointer" />
-                                    <TrashSimpleIcon size={25} weight="bold" className="text-red-400 hover:text-red-500 transition-colors duration-200 cursor-pointer" />
+                                    {useActionModal ?
+                                        (
+                                            <ActionModal
+                                                trigger={
+                                                    <PencilSimpleIcon size={25} weight="bold" onClick={() => setOpenEditPost(true)} className="text-blue-400 hover:text-blue-500 transition-colors duration-200 cursor-pointer" />
+                                                }
+                                                remarkText={remarkText}
+                                                onApprove={() => alert("Approved")}
+                                                onRemark={() => alert("Remarked: " + remarkText)}
+                                                onReject={() => alert("Rejected " + remarkText)}
+                                            />
+                                        ) : (
+                                            <>
+                                                <PencilSimpleIcon size={25} weight="bold" onClick={() => setOpenEditPost(true)} className="text-blue-400 hover:text-blue-500 transition-colors duration-200 cursor-pointer" />
+                                                <EditPostModal open={openEditPost} onOpenChange={setOpenEditPost} />
+
+                                            </>
+                                        )}
+
+                                    {showDelete &&
+                                        <TrashSimpleIcon size={25} weight="bold" className="text-red-400 hover:text-red-500 transition-colors duration-200 cursor-pointer" />
+                                    }
                                 </div>
                             </div>
+
+                            {showAddRemarkBox &&
+                                (
+                                    <div className="pt-4">
+                                        <AddRemarkBox value={remarkText} onChange={setRemarkText} />
+                                    </div>
+                                )
+                            }
 
                             <a className="font-small text-[#6E7793] pt-3 block italic">Last updated: 20 January by Admin: Teacher Hanafiah</a>
                         </div>
@@ -136,7 +175,6 @@ const PostList: React.FC<PostListProps> = ({ title, date, status, showStatus = t
                 )
             }
 
-            <EditPostModal open={openEditPost} onOpenChange={setOpenEditPost} />
         </div>
 
     );

--- a/src/components/RemarkBox.tsx
+++ b/src/components/RemarkBox.tsx
@@ -8,7 +8,7 @@ const RemarkBox = () => {
                 <ChatIcon size={20} weight="bold" className='text-[#007BD3]' />
                 <a className="text-[#007BD3] font-semibold">Admin Remarks</a>
             </div>
-            <a className="text-[#007BD3] font-medium  max-h-15 overflow-y-auto pr-2 leading-5">Please add specific time slots and room numbers for better clarity. Please add specific time slots and room numbers for better clarity. Please add specific time slots and room numbers for better clarity. Please add specific time slots and room numbers for better clarity.</a>
+            <a className="text-[#007BD3] font-medium  max-h-15 overflow-y-auto pr-2 leading-5 text-justify">Please add specific time slots and room numbers for better clarity. Please add specific time slots and room numbers for better clarity. Please add specific time slots and room numbers for better clarity. Please add specific time slots and room numbers for better clarity.</a>
         </div>
     );
 };


### PR DESCRIPTION
Added 'Add Remark' text field to manage-posts for admins to put Remarks whenever Remarking or Rejecting a post. Also added props to handle UI visibility throughout pages. Also put handler to check if Remark Text is absent when Remarking or Rejecting a post.

<img width="974" height="931" alt="image" src="https://github.com/user-attachments/assets/a18b1513-4f26-428f-877a-a00030531253" />
<img width="978" height="884" alt="image" src="https://github.com/user-attachments/assets/2f1d0dd0-9bc7-4cbd-bdb9-9133b84c4feb" />
<img width="980" height="886" alt="image" src="https://github.com/user-attachments/assets/58c237c4-d065-4bc8-a8bb-137f61f88d7d" />


As for the prompt, it will be replaced when I am rajin enough to make a custom prompt XD